### PR TITLE
Use inputValue and textContent instead of evaluate in SelectTag.label

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "playwright-pom-materials",
-  "version": "1.0.0",
+  "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "playwright-pom-materials",
-      "version": "1.0.0",
+      "version": "0.1.1",
       "license": "ISC",
       "dependencies": {
         "playwright-core": "^1.29.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-pom-materials",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Playwright POM materials",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/materials/SelectTag.ts
+++ b/src/materials/SelectTag.ts
@@ -40,13 +40,9 @@ export class SelectTag extends Clickable {
   }
 
   async label(): Promise<string | undefined> {
-    return this.locator.evaluate((el): string | undefined => {
-      const sel = el as HTMLSelectElement;
-      const idx = sel.selectedIndex;
-      return idx > -1
-        ? sel.options[idx].textContent?.trim() || undefined
-        : undefined;
-    });
+    const value = await this.locator.inputValue();
+    const l = this.locator.locator(`option[value="${value}"]`);
+    return (await l.textContent()) || undefined;
   }
 
   set(


### PR DESCRIPTION
Locator.evaluate method is not recommended to use because operations by using it are not reported in playwright trace.
So use [Locator.inputValue](https://playwright.dev/docs/api/class-locator#locator-input-value) to get selected option value and [Locator.textContent](https://playwright.dev/docs/api/class-locator#locator-text-content) to get the textContent of the selected option.
