### PR TITLE
Update playwright-core version from 1.29.1 to 1.35.1 or later

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "playwright-pom-materials",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "playwright-pom-materials",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "license": "MIT",
       "dependencies": {
-        "playwright-core": "^1.29.1"
+        "playwright-core": "^1.35.1"
       },
       "devDependencies": {
         "@types/node": "^18.11.18",
@@ -2176,14 +2176,14 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.29.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.29.1.tgz",
-      "integrity": "sha512-20Ai3d+lMkWpI9YZYlxk8gxatfgax5STW8GaMozAHwigLiyiKQrdkt7gaoT9UQR8FIVDg6qVXs9IoZUQrDjIIg==",
+      "version": "1.38.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.38.1.tgz",
+      "integrity": "sha512-tQqNFUKa3OfMf4b2jQ7aGLB8o9bS3bOY0yMEtldtC2+spf8QXG9zvXLTXUeRsoNuxEYMgLYR+NXfAa1rjKRcrg==",
       "bin": {
-        "playwright": "cli.js"
+        "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/prelude-ls": {
@@ -4291,9 +4291,9 @@
       "dev": true
     },
     "playwright-core": {
-      "version": "1.29.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.29.1.tgz",
-      "integrity": "sha512-20Ai3d+lMkWpI9YZYlxk8gxatfgax5STW8GaMozAHwigLiyiKQrdkt7gaoT9UQR8FIVDg6qVXs9IoZUQrDjIIg=="
+      "version": "1.38.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.38.1.tgz",
+      "integrity": "sha512-tQqNFUKa3OfMf4b2jQ7aGLB8o9bS3bOY0yMEtldtC2+spf8QXG9zvXLTXUeRsoNuxEYMgLYR+NXfAa1rjKRcrg=="
     },
     "prelude-ls": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
     "typescript": "^4.9.4"
   },
   "dependencies": {
-    "playwright-core": "^1.29.1"
+    "playwright-core": "^1.35.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-pom-materials",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Playwright POM materials",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
Playwright-1.35 includes a breaking change about playwright-core.
See https://playwright.dev/docs/release-notes#%EF%B8%8F-breaking-changes for more detail.

This PR updates playwright-core version from 1.29.1 to 1.35.1 or later.
