### PR TITLE
Use @playwright/test instead of playwright-core

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 #playwright-pom-materials
+
+## Release
+
+1. Modify code and commit them.
+2. npm version major/minor/patch
+3. npm publish

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "playwright-pom-materials",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "playwright-pom-materials",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "license": "MIT",
       "dependencies": {
         "@playwright/test": "^1.35.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.7",
       "license": "MIT",
       "dependencies": {
-        "playwright-core": "^1.35.1"
+        "@playwright/test": "^1.35.1"
       },
       "devDependencies": {
         "@types/node": "^18.11.18",
@@ -154,6 +154,20 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.39.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.39.0.tgz",
+      "integrity": "sha512-3u1iFqgzl7zr004bGPYiN/5EZpRUSFddQBra8Rqll5N0/vfpqlP9I9EXqAoGacuAbX6c9Ulg/Cjqglp5VkK6UQ==",
+      "dependencies": {
+        "playwright": "1.39.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/@types/json-schema": {
@@ -1193,6 +1207,19 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
@@ -2311,10 +2338,27 @@
         "node": ">=4"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.39.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.39.0.tgz",
+      "integrity": "sha512-naE5QT11uC/Oiq0BwZ50gDmy8c8WLPRTEWuSSFVG2egBka/1qMoSqYQcROMT9zLwJ86oPofcTH2jBY/5wWOgIw==",
+      "dependencies": {
+        "playwright-core": "1.39.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
     "node_modules/playwright-core": {
-      "version": "1.38.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.38.1.tgz",
-      "integrity": "sha512-tQqNFUKa3OfMf4b2jQ7aGLB8o9bS3bOY0yMEtldtC2+spf8QXG9zvXLTXUeRsoNuxEYMgLYR+NXfAa1rjKRcrg==",
+      "version": "1.39.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.39.0.tgz",
+      "integrity": "sha512-+k4pdZgs1qiM+OUkSjx96YiKsXsmb59evFoqv8SKO067qBA+Z2s/dCzJij/ZhdQcs2zlTAgRKfeiiLm8PQ2qvw==",
       "bin": {
         "playwright-core": "cli.js"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "playwright-pom-materials",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "playwright-pom-materials",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "license": "MIT",
       "dependencies": {
         "@playwright/test": "^1.35.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-pom-materials",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Playwright POM materials",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
     "typescript": "^4.9.4"
   },
   "dependencies": {
-    "playwright-core": "^1.35.1"
+    "@playwright/test": "^1.35.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-pom-materials",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Playwright POM materials",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/helpers/playwright/LocatorPredicate.ts
+++ b/src/helpers/playwright/LocatorPredicate.ts
@@ -1,4 +1,4 @@
-import {Locator} from 'playwright-core';
+import {Locator} from '@playwright/test';
 
 export type LocatorPredicate = (l: Locator) => Promise<boolean>;
 

--- a/src/helpers/playwright/locator_attr.ts
+++ b/src/helpers/playwright/locator_attr.ts
@@ -1,4 +1,4 @@
-import {Locator} from 'playwright-core';
+import {Locator} from '@playwright/test';
 
 export const hasDisabledAttr = async (l: Locator): Promise<boolean> => {
   return l.evaluate((el: SVGElement | HTMLElement): boolean => {

--- a/src/helpers/playwright/locator_utils.ts
+++ b/src/helpers/playwright/locator_utils.ts
@@ -1,4 +1,4 @@
-import {Frame, Page, Locator} from 'playwright-core';
+import {Frame, Page, Locator} from '@playwright/test';
 import {isFrame, isPage} from './type_guards';
 
 // See https://github.com/microsoft/playwright/blob/v1.14.1/src/client/locator.ts

--- a/src/helpers/playwright/pwRetry.ts
+++ b/src/helpers/playwright/pwRetry.ts
@@ -1,4 +1,4 @@
-import {Locator, Page} from 'playwright-core';
+import {Locator, Page} from '@playwright/test';
 import {config} from '../config';
 
 import {retry, retryAttempts} from '../retry';

--- a/src/helpers/playwright/sleepFunc.ts
+++ b/src/helpers/playwright/sleepFunc.ts
@@ -1,4 +1,4 @@
-import {Frame, Locator, Page} from 'playwright-core';
+import {Frame, Locator, Page} from '@playwright/test';
 import {getFrame} from './locator_utils';
 
 export const sleepFunc = (

--- a/src/helpers/playwright/type_guards.ts
+++ b/src/helpers/playwright/type_guards.ts
@@ -1,4 +1,4 @@
-import {Frame, Page, Locator} from 'playwright-core';
+import {Frame, Page, Locator} from '@playwright/test';
 
 export const isFrame = (x: unknown): x is Frame => {
   if (typeof x !== 'object' || x === null) return false;

--- a/src/materials/Clickable.ts
+++ b/src/materials/Clickable.ts
@@ -1,4 +1,4 @@
-import {Locator} from 'playwright-core';
+import {Locator} from '@playwright/test';
 
 import {RetryOptions, LocatorPredicate} from '../helpers/playwright';
 

--- a/src/materials/Displayable.ts
+++ b/src/materials/Displayable.ts
@@ -1,4 +1,4 @@
-import {Locator} from 'playwright-core';
+import {Locator} from '@playwright/test';
 
 export class Displayable {
   constructor(readonly locator: Locator) {}

--- a/src/materials/InputText.ts
+++ b/src/materials/InputText.ts
@@ -1,4 +1,4 @@
-import {Locator} from 'playwright-core';
+import {Locator} from '@playwright/test';
 import {pwRetryUi, RetryOptions} from '../helpers/playwright';
 
 import {Operable, OperableOptions} from './Operable';

--- a/src/materials/Operable.ts
+++ b/src/materials/Operable.ts
@@ -1,4 +1,4 @@
-import {Locator} from 'playwright-core';
+import {Locator} from '@playwright/test';
 
 import {
   LocatorPredicate,

--- a/src/materials/RadioButtons.ts
+++ b/src/materials/RadioButtons.ts
@@ -1,4 +1,4 @@
-import {Locator, Page} from 'playwright-core';
+import {Locator, Page} from '@playwright/test';
 import {Selectable, SelectableOptions} from './Selectable';
 
 export type SelectableArgs = string | [string, SelectableOptions?];

--- a/src/materials/SelectTag.ts
+++ b/src/materials/SelectTag.ts
@@ -1,4 +1,4 @@
-import {Locator} from 'playwright-core';
+import {Locator} from '@playwright/test';
 import {Clickable, ClickableOptions} from './Clickable';
 import {pwRetry} from '../helpers/playwright';
 

--- a/src/materials/Selectable.ts
+++ b/src/materials/Selectable.ts
@@ -1,4 +1,4 @@
-import {Locator} from 'playwright-core';
+import {Locator} from '@playwright/test';
 
 import {
   LocatorPredicate,


### PR DESCRIPTION
Previously, there was no part that depended on @playwright/test, so playwright-pom-materials has depended on playwright-core. But the difference between @playwright/test referenced by the application's E2E test and playwright-core referenced by playwright-pom-materials sometimes makes issues. So I changed playwright-pom-materials to use @playwright/test instead of playwright-core.
